### PR TITLE
Repair to the audio in the p5.func "easing3_animation" example

### DIFF
--- a/examples/easing3_animation/index.html
+++ b/examples/easing3_animation/index.html
@@ -3,9 +3,8 @@
   <head>
     <meta charset="UTF-8">
     <title>p5.func</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/p5.min.js" type="text/javascript"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/addons/p5.dom.min.js" type="text/javascript"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.16/addons/p5.sound.min.js" type="text/javascript"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.10.0/p5.min.js" type="text/javascript"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.10.0/addons/p5.sound.min.js" type="text/javascript"></script>
     <script src="../../lib/p5.func.js" type="text/javascript"></script>
 
     <script src="sketch.js" type="text/javascript"></script>

--- a/examples/easing3_animation/sketch.js
+++ b/examples/easing3_animation/sketch.js
@@ -9,13 +9,12 @@ var t = 0.;
 var doclear;
 
 var x, y, tx, ty, x1, y1, px, py;
-
 var osc, rev;
-
 var tb; // textbox
 
 function setup()
 {
+  getAudioContext().suspend();
   createCanvas(800, 600);
   background(255);
   fill(0);
@@ -62,7 +61,7 @@ function draw()
 
   var hs = '';
   hs+= 'p5.Ease(): ' + curstyle + '<br><br>';
-  hs+= 'click around.';
+  hs+= 'click around. pitch is proportional to speed.';
 
   tb.html(hs);
 
@@ -84,6 +83,7 @@ function draw()
 
 function mousePressed()
 {
+  userStartAudio();
   curstyle = random(styles);
   x = px;
   y = py;


### PR DESCRIPTION
The synthesized audio aspect of the [easing3_animation](https://github.com/IDMNYU/p5.js-func/tree/master/examples/easing3_animation/) demo is very compelling and economical. The audio in this demo no longer works because of browser policy changes regarding audio. For example, running the [official online demo](https://idmnyu.github.io/p5.js-func/examples/easing3_animation/) at IDMNYU in Chrome produces the error:
```
The AudioContext was not allowed to start. 
It must be resumed (or created) after a user gesture on the page.
```

A repaired example can be found online [here](https://editor.p5js.org/golan/sketches/u8BwhapXW) and in this pull request. Changes include: 

* Bumping p5.js and p5.sound.js from 0.5.16 to 1.10.0; removing p5.dom.min.js (no longer used)
* Adding `getAudioContext().suspend();` in `setup()`
* Adding the newish [`userStartAudio();`](https://archive.p5js.org/reference/#/p5/userStartAudio) function in `mousePressed()`. 
